### PR TITLE
fix(schema): document full JSON:API envelope for paginated responses

### DIFF
--- a/drf_spectacular_jsonapi/schemas/pagination.py
+++ b/drf_spectacular_jsonapi/schemas/pagination.py
@@ -1,33 +1,115 @@
+from typing import Any, Dict
+
 from rest_framework_json_api.pagination import JsonApiPageNumberPagination
+
+# JSON:API link values may be a URI string, a link object, or null. OpenAPI 3.0
+# full oneOf for link objects is deferred; nullable URI covers the common case.
+# See https://jsonapi.org/format/#document-links
+
+
+def _top_level_link_value(*, example: Any, description_extra: str = "") -> Dict[str, Any]:
+    base = (
+        "A JSON:API link: URI string, link object, or null. "
+        "See https://jsonapi.org/format/#document-links."
+    )
+    if description_extra:
+        base = f"{description_extra} {base}"
+    return {
+        "type": "string",
+        "format": "uri",
+        "nullable": True,
+        "example": example,
+        "description": base.strip(),
+    }
 
 
 class JsonApiPageNumberPagination(JsonApiPageNumberPagination):
 
-    def get_paginated_response_schema(self, schema):
+    def get_paginated_response_schema(self, schema: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Return a JSON:API document schema for a paginated collection response.
 
+        Top-level ``data`` uses the incoming ``schema`` unchanged. Optional
+        ``links`` and ``meta`` follow JSON:API document and pagination rules:
+        https://jsonapi.org/format/#fetching-pagination
+        """
+        # Examples mirror JSON:API's use of http://example.com and page[number]/page[size].
+        example_base = "http://example.com/articles?page%5Bsize%5D=10"
         return {
-            'type': 'object',
-            'properties': {
-                # TODO: add json:api link objects for pagination
-                # 'count': {
-                #     'type': 'integer',
-                #     'example': 123,
-                # },
-                # 'next': {
-                #     'type': 'string',
-                #     'nullable': True,
-                #     'format': 'uri',
-                #     'example': 'http://api.example.org/accounts/?{page_query_param}=4'.format(
-                #         page_query_param=self.page_query_param)
-                # },
-                # 'previous': {
-                #     'type': 'string',
-                #     'nullable': True,
-                #     'format': 'uri',
-                #     'example': 'http://api.example.org/accounts/?{page_query_param}=2'.format(
-                #         page_query_param=self.page_query_param)
-                # },
-                'data': schema,
+            "type": "object",
+            "properties": {
+                "data": schema,
+                "links": {
+                    "type": "object",
+                    "description": (
+                        "Pagination links for the primary data. These keys MUST be used "
+                        "for pagination links; each MUST be omitted or `null` when that "
+                        "link is unavailable. Values follow JSON:API link rules (URI string, "
+                        "link object, or null). "
+                        "https://jsonapi.org/format/#fetching-pagination "
+                        "https://jsonapi.org/format/#document-links"
+                    ),
+                    "properties": {
+                        "first": _top_level_link_value(
+                            example=f"{example_base}&page%5Bnumber%5D=1",
+                            description_extra="The first page of data.",
+                        ),
+                        "last": _top_level_link_value(
+                            example=f"{example_base}&page%5Bnumber%5D=9",
+                            description_extra="The last page of data.",
+                        ),
+                        "prev": _top_level_link_value(
+                            example=f"{example_base}&page%5Bnumber%5D=1",
+                            description_extra="The previous page of data.",
+                        ),
+                        "next": _top_level_link_value(
+                            example=f"{example_base}&page%5Bnumber%5D=3",
+                            description_extra="The next page of data.",
+                        ),
+                    },
+                    "additionalProperties": False,
+                },
+                "meta": {
+                    "type": "object",
+                    "description": (
+                        "Non-standard meta-information. Page-number stacks often nest "
+                        "totals under `pagination`. JSON:API does not define these keys. "
+                        "Servers MAY add other `meta` members; this schema documents the "
+                        "usual djangorestframework-json-api shape only. "
+                        "https://jsonapi.org/format/#document-meta"
+                    ),
+                    "properties": {
+                        "pagination": {
+                            "type": "object",
+                            "description": (
+                                "Typical page-number metadata from "
+                                "djangorestframework-json-api; not mandated by JSON:API."
+                            ),
+                            "properties": {
+                                "count": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "example": 42,
+                                    "description": "Total number of resources across all pages.",
+                                },
+                                "page": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "example": 2,
+                                    "description": "Current page number (1-based).",
+                                },
+                                "pages": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "example": 5,
+                                    "description": "Total number of pages.",
+                                },
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                    "additionalProperties": False,
+                },
             },
-            "required": ["data"]
+            "required": ["data"],
         }

--- a/drf_spectacular_jsonapi/schemas/pagination.py
+++ b/drf_spectacular_jsonapi/schemas/pagination.py
@@ -8,6 +8,16 @@ from rest_framework_json_api.pagination import JsonApiPageNumberPagination
 
 
 def _top_level_link_value(*, example: Any, description_extra: str = "") -> Dict[str, Any]:
+    """helper function to generate schema
+
+    Args:
+        example (Any): example of a valid value of this schema
+        description_extra (str, optional): additional description for the link. Defaults to "".
+
+    Returns:
+        Dict[str, Any]: schema for the link value, which may be a URI string, a link object, or null. OpenAPI 3.0
+    """
+    
     base = (
         "A JSON:API link: URI string, link object, or null. "
         "See https://jsonapi.org/format/#document-links."

--- a/tests/tests_schema.py
+++ b/tests/tests_schema.py
@@ -5,6 +5,8 @@ from django.test.testcases import SimpleTestCase
 from drf_spectacular.generators import SchemaGenerator
 from drf_spectacular.validation import validate_schema
 
+from drf_spectacular_jsonapi.schemas.pagination import JsonApiPageNumberPagination
+
 
 class SimpleSchemaTestCase(SimpleTestCase):
 
@@ -243,10 +245,37 @@ class TestSchemaOutputForSimpleModelSerializer(SimpleSchemaTestCase):
             self.schema["paths"]["/albums/"]["get"]["responses"]["200"]["content"]["application/vnd.api+json"]["schema"]["$ref"],
             "#/components/schemas/PaginatedAlbumList"
         )
+        paginated = self.schema["components"]["schemas"]["PaginatedAlbumList"]
         self.assertEqual(
-            self.schema["components"]["schemas"]["PaginatedAlbumList"]["properties"]["data"]["items"]["$ref"],
+            paginated["properties"]["data"]["items"]["$ref"],
             "#/components/schemas/Album"
         )
+        self.assertEqual(paginated["required"], ["data"])
+        links_schema = paginated["properties"]["links"]
+        self.assertIs(links_schema.get("additionalProperties"), False)
+        link_props = links_schema["properties"]
+        self.assertEqual(
+            set(link_props.keys()),
+            {"first", "last", "next", "prev"},
+        )
+        for key in link_props:
+            self.assertEqual(link_props[key]["type"], "string")
+            self.assertEqual(link_props[key]["format"], "uri")
+            self.assertTrue(link_props[key].get("nullable"))
+            self.assertIn("example", link_props[key])
+        meta_schema = paginated["properties"]["meta"]
+        self.assertIs(meta_schema.get("additionalProperties"), False)
+        pagination_meta = meta_schema["properties"]["pagination"]
+        self.assertIs(pagination_meta.get("additionalProperties"), False)
+        self.assertEqual(
+            set(pagination_meta["properties"].keys()),
+            {"count", "page", "pages"},
+        )
+        self.assertEqual(pagination_meta["properties"]["count"]["type"], "integer")
+        self.assertEqual(pagination_meta["properties"]["page"]["type"], "integer")
+        self.assertEqual(pagination_meta["properties"]["pages"]["type"], "integer")
+        for key in ("count", "page", "pages"):
+            self.assertIn("example", pagination_meta["properties"][key])
 
         self.assertEqual(
             self.schema["paths"]["/albums/{id}/"]["get"]["responses"]["200"]["content"]["application/vnd.api+json"]["schema"]["$ref"],
@@ -639,6 +668,50 @@ class TestSchemaOutputForSimpleModelSerializer(SimpleSchemaTestCase):
             }
         )
         self.assertEqual(expected, calculated)
+
+
+class TestJsonApiPageNumberPaginationSchema(SimpleTestCase):
+    """Direct tests for paginated JSON:API document envelope schema."""
+
+    def test_get_paginated_response_schema_matches_embedded_document(self):
+        paginator = JsonApiPageNumberPagination()
+        data_schema = {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/Album"},
+        }
+        envelope = paginator.get_paginated_response_schema(data_schema)
+        self.assertIs(envelope["properties"]["data"], data_schema)
+        self.assertEqual(envelope["required"], ["data"])
+
+        minimal_openapi = {
+            "openapi": "3.0.3",
+            "info": {"title": "t", "version": "1"},
+            "paths": {
+                "/albums/": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/vnd.api+json": {
+                                        "schema": envelope,
+                                    }
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Album": {
+                        "type": "object",
+                        "properties": {"type": {"type": "string"}},
+                    }
+                }
+            },
+        }
+        validate_schema(minimal_openapi)
 
 
 class TestSchemaOutputForDifferentIdFieldName(SimpleSchemaTestCase):


### PR DESCRIPTION
## Summary

- Add `nomad/jobs/public_api/cron/` (same shape as `scraper/cron`): packvars for the **public-api** image + weekly **`manage_public_api.py cleartokens`** job (`pricing` namespace, Sunday 03:00 server TZ).
- Default **`public-api`** image tag is **`prd-deploy`** in both `public_api.nomad` and cron packvars (aligned with CI deploy).

Fix #3 