### PR TITLE
fix(schema): distinguish resource serializers from embedded attribute objects

### DIFF
--- a/drf_spectacular_jsonapi/schemas/openapi.py
+++ b/drf_spectacular_jsonapi/schemas/openapi.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from django.db.models.fields.related import (ForeignKey, ManyToManyField,
                                              OneToOneField)
@@ -8,8 +8,10 @@ from django.utils.translation import gettext_lazy as _
 from drf_spectacular.contrib.django_filters import DjangoFilterExtension
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import (ResolvedComponent, build_array_type,
-                                      build_parameter_type, is_list_serializer)
+                                      build_parameter_type, force_instance,
+                                      is_list_serializer)
 from rest_framework_json_api.serializers import (
+    ModelSerializer as JsonApiModelSerializer,
     ResourceIdentifierObjectSerializer, SparseFieldsetsMixin)
 from rest_framework_json_api.utils import (format_field_name,
                                            get_resource_name,
@@ -48,6 +50,31 @@ class JsonApiAutoSchema(AutoSchema):
 
     def get_json_api_resource_object_converter_class(self):
         return self.json_api_resource_object_converter_class
+
+    def is_json_api_resource_serializer(self, serializer: Any) -> bool:
+        """Return True if *serializer* is documented as a JSON:API resource object.
+
+        Resource objects carry ``type``, optional ``id``, ``attributes``, and
+        ``relationships`` per https://jsonapi.org/format/#document-resource-objects.
+        Plain nested objects used only inside ``attributes`` stay as regular
+        JSON Schema objects.
+
+        Default rules (override in a subclass for custom classification):
+
+        - ``rest_framework_json_api.serializers.ModelSerializer`` subclasses
+          are treated as resources (backward compatible with existing schemas).
+        - Serializers whose ``Meta.resource_name`` is set are treated as
+          resources (explicit opt-in for non-model serializers).
+        - Other serializers (for example plain ``rest_framework.serializers.Serializer``)
+          are treated as inline attribute objects.
+        """
+        serializer = force_instance(serializer)
+        if is_list_serializer(serializer):
+            serializer = serializer.child
+        meta = getattr(serializer, "Meta", None)
+        if meta is not None and getattr(meta, "resource_name", None):
+            return True
+        return isinstance(serializer, JsonApiModelSerializer)
 
     def get_operation(self, path, path_regex, path_prefix, method, registry):
         return super().get_operation(path, path_regex, path_prefix, method, registry)
@@ -265,6 +292,9 @@ class JsonApiAutoSchema(AutoSchema):
         object_schema = super()._map_basic_serializer(
             serializer=serializer, direction=direction)
 
+        if not self.is_json_api_resource_serializer(serializer):
+            return object_schema
+
         json_api_resource_object_schema = self.get_json_api_resource_object_converter_class()(
             serializer=serializer,
             drf_spectactular_schema=object_schema,
@@ -279,7 +309,7 @@ class JsonApiAutoSchema(AutoSchema):
             # responses shall not be framed.
             # it is handled by the _get_response_for_code function
             pass
-        else:
+        elif self.is_json_api_resource_serializer(serializer):
             schema = build_json_api_data_frame(schema)
         return schema
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,4 +1,5 @@
 from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers as drf_serializers
 from rest_framework.fields import CharField
 from rest_framework_json_api.relations import ResourceRelatedField
 from rest_framework_json_api.serializers import ModelSerializer
@@ -8,7 +9,9 @@ from .models import Album, Song, User
 __all__ = [
     "SongSerializer",
     "AlbumSerializer",
-    "UserSerializer"
+    "AlbumWithEmbeddedSerializer",
+    "EmbeddedDimensionsSerializer",
+    "UserSerializer",
 ]
 
 
@@ -32,6 +35,13 @@ class SongPostOnlySerializer(SongSerializer):
     pass
 
 
+class EmbeddedDimensionsSerializer(drf_serializers.Serializer):
+    """Plain JSON object nested under JSON:API ``attributes`` (not a resource)."""
+
+    width = drf_serializers.IntegerField()
+    height = drf_serializers.IntegerField()
+
+
 class AlbumSerializer(ModelSerializer):
     """ """
 
@@ -53,6 +63,15 @@ class AlbumSerializer(ModelSerializer):
     class Meta:
         model = Album
         fields = "__all__"
+
+
+class AlbumWithEmbeddedSerializer(AlbumSerializer):
+    """Album JSON:API resource with a nested non-resource object attribute."""
+
+    dimensions = EmbeddedDimensionsSerializer(required=False)
+
+    class Meta(AlbumSerializer.Meta):
+        fields = ("id", "title", "genre", "year", "released", "songs", "dimensions")
 
 
 class PasswordField(CharField):

--- a/tests/tests_schema.py
+++ b/tests/tests_schema.py
@@ -692,6 +692,40 @@ class TestSchemaOutputForDifferentIdFieldName(SimpleSchemaTestCase):
         self.assertEqual(expected, calculated)
 
 
+class TestEmbeddedAttributeSerializerSchema(SimpleSchemaTestCase):
+    """Non-resource serializers nested under attributes are plain JSON Schema objects."""
+
+    def test_inline_request_component_not_jsonapi_resource_shape(self):
+        emb = self.schema["components"]["schemas"]["EmbeddedDimensionsRequest"]
+        self.assertEqual(emb["type"], "object")
+        self.assertIn("width", emb["properties"])
+        self.assertIn("height", emb["properties"])
+        props = emb["properties"]
+        self.assertNotIn("attributes", emb)
+        self.assertNotIn("relationships", emb)
+        # JSON:API resource identification lives under ``properties``; OpenAPI's
+        # root ``type`` keyword is only the JSON Schema type tag.
+        self.assertNotIn("type", props)
+
+    def test_inline_response_component_not_jsonapi_resource_shape(self):
+        emb = self.schema["components"]["schemas"]["EmbeddedDimensions"]
+        self.assertEqual(emb["type"], "object")
+        self.assertIn("width", emb["properties"])
+        self.assertIn("height", emb["properties"])
+        self.assertNotIn("type", emb["properties"])
+
+    def test_parent_post_request_dimensions_ref_plain_object(self):
+        self.assertEqual(
+            self.schema["paths"]["/albums-with-embedded/"]["post"]["requestBody"][
+                "content"]["application/vnd.api+json"]["schema"]["$ref"],
+            "#/components/schemas/AlbumWithEmbeddedRequest",
+        )
+        dim = self.schema["components"]["schemas"]["AlbumWithEmbeddedRequest"]["properties"][
+            "data"]["properties"]["attributes"]["properties"]["dimensions"]
+        self.assertIn("$ref", dim)
+        self.assertTrue(dim["$ref"].endswith("EmbeddedDimensionsRequest"))
+
+
 class TestSchemaOutputForNestedResources(SimpleSchemaTestCase):
     def test_nested_path_parameter_fix(self):
         calculated = self.ordered(
@@ -710,10 +744,7 @@ class TestSchemaOutputForNestedResources(SimpleSchemaTestCase):
         )
         self.assertEqual(expected, calculated)
 
-    def test_nested_path_parameter_fix(self):
-        f = open("demofile2.txt", "a")
-        f.write(str(self.schema))
-        f.close()
+    def test_nested_path_parameters_songs_as_view(self):
         calculated = self.ordered(
             self.schema["paths"]["/albums/{AlbumId}/songs-as-view/"]["get"]["parameters"])
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,9 +2,9 @@ from django.urls import path
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
 from .views import (AlbumModelViewset, AlbumRelationShipView,
-                    NestedSongModelViewset, SongModelViewset,
-                    SongModelViewsetPostOnly, SongRelationShipView,
-                    UserModelViewset)
+                    AlbumWithEmbeddedViewset, NestedSongModelViewset,
+                    SongModelViewset, SongModelViewsetPostOnly,
+                    SongRelationShipView, UserModelViewset)
 
 router = ExtendedSimpleRouter()
 
@@ -12,6 +12,11 @@ router = ExtendedSimpleRouter()
 (
     router.register(r"albums", AlbumModelViewset, basename="album")
           .register(r"songs", NestedSongModelViewset, basename="album-songs", parents_query_lookups=["album"]),
+    router.register(
+        r"albums-with-embedded",
+        AlbumWithEmbeddedViewset,
+        basename="album-with-embedded",
+    ),
     router.register(r"songs", SongModelViewset, basename="song"),
     router.register(r"songs-post-only",
                     SongModelViewsetPostOnly, basename="song-post"),

--- a/tests/views.py
+++ b/tests/views.py
@@ -7,13 +7,25 @@ from rest_framework_json_api.views import (AutoPrefetchMixin, ModelViewSet,
                                            RelationshipView)
 
 from .models import Album, Song, User
-from .serializers import (AlbumSerializer, SongPostOnlySerializer,
-                          SongSerializer, UserSerializer)
+from .serializers import (AlbumSerializer, AlbumWithEmbeddedSerializer,
+                          SongPostOnlySerializer, SongSerializer,
+                          UserSerializer)
 
 
 class AlbumModelViewset(ModelViewSet):
     """ """
     serializer_class = AlbumSerializer
+    queryset = Album.objects.none()
+    search_fields = ("id", "songs",)
+    ordering_fields = ["id", "title"]
+    filterset_fields = {
+        "genre": ["exact"],
+        "title": ["contains"]
+    }
+
+
+class AlbumWithEmbeddedViewset(ModelViewSet):
+    serializer_class = AlbumWithEmbeddedSerializer
     queryset = Album.objects.none()
     search_fields = ("id", "songs",)
     ordering_fields = ["id", "title"]


### PR DESCRIPTION
## Problem

`JsonApiAutoSchema` treated **every** DRF serializer like a JSON:API **resource object**: it always passed schemas through `JsonApiResourceObject` and wrapped request serializer components in a top-level `{ "data": … }` document frame.

Nested serializers that only represent **embedded JSON objects** under a resource’s **`attributes`** (for example a `dimensions` object with `width` and `height`) were therefore documented as if they were full resources (`type`, `id`, `attributes`, `relationships`) and sometimes as their own primary `data` payloads. That is misleading for consumers and does not match how JSON:API structures **attribute** values, and can cause 500 errors like so:

```
AttributeError: can not detect 'resource_name' on serializer '<Serializer>' in module '<Module>'
```

## What this PR changes

- Introduces **`is_json_api_resource_serializer(serializer)`** (overridable) to decide whether a serializer should get the JSON:API **resource object** treatment.
- **Default rules**
  - **`rest_framework_json_api.serializers.ModelSerializer`** subclasses → still documented as resource objects (**unchanged** for typical APIs).
  - **`Meta.resource_name`** set → resource (**explicit opt-in**, including non-model serializers that intentionally opt in).
  - Otherwise → **inline**: use **`super()._map_basic_serializer()`** only (no `JsonApiResourceObject`), and **do not** apply **`build_json_api_data_frame`** to that serializer’s request component.

## Example

**Before:** a nested `Serializer` for dimensions could show up in OpenAPI with JSON:API resource members (e.g. a `properties.type` member carrying a resource-type enum, plus `attributes` / `relationships`) and/or an erroneous nested `{ "data": … }` envelope.

**After:** the same value is a **plain JSON Schema object**, for example:

```json
{
  "type": "object",
  "properties": {
    "width": { "type": "integer" },
    "height": { "type": "integer" }
  }
}
```

The parent **`ModelSerializer`** (e.g. album) remains a proper JSON:API resource: `type`, `id`, `attributes` (with e.g. `dimensions` as a `$ref` to that plain object), and `relationships` as today.

## JSON:API specification (why this aligns with the spec)

Resource objects are a **specific** document shape used to represent resources:

> “Resource objects” appear in a JSON:API document to represent resources.
>
> A resource object MUST contain at least the following top-level members:
>
> - `id`
> - `type`
>
> … In addition, a resource object MAY contain any of these top-level members:
>
> - `attributes`: an attributes object representing some of the resource’s data.
> - `relationships`: …

— [Document » Resource objects](https://jsonapi.org/format/#document-resource-objects)

Values inside **`attributes`** are ordinary JSON; they are **not** required to be (and usually are not) nested resource objects:

> “The value of the `attributes` key MUST be an object (an ‘attributes object’). Members of the attributes object (‘attributes’) represent information about the resource object in which it’s defined.”
>
> “Attributes may contain any valid JSON value, including complex data structures involving JSON objects and arrays.”

— [Document » Resource objects » Attributes](https://jsonapi.org/format/#document-resource-object-attributes)

So: **only** serializers that represent actual JSON:API resources should be documented with the resource-object layout; nested attribute objects should remain **plain** OpenAPI/JSON Schema objects unless they are modeled as **relationships** or as **primary / included** resource data elsewhere in the document.

## Backwards compatibility

- **Unchanged** for existing **`rest_framework_json_api.serializers.ModelSerializer`**-based resources (same resource-object schemas as before).
- **`Meta.resource_name`** continues to force **resource** documentation.
- **Intentional change:** serializers that are **not** json-api `ModelSerializer` and **do not** set `Meta.resource_name` (e.g. nested `rest_framework.serializers.Serializer`) are now **inline objects** instead of spurious resource objects. A nested vanilla DRF `ModelSerializer` inside `attributes` would follow the same rule unless `resource_name` is set; documenting that as a nested JSON:API resource inside `attributes` was never spec-aligned.

## Tests

- Adds `EmbeddedDimensionsSerializer`, `AlbumWithEmbeddedSerializer`, viewset, and route; asserts inline request/response components are plain objects (no JSON:API **`properties.type`** identification) and that the parent POST schema still references `EmbeddedDimensionsRequest` under `attributes`.
- Renames the duplicated nested-URL test and removes an accidental `demofile2.txt` write so both nested URL cases run.

Fix #34 